### PR TITLE
Add Dockerfile for rra-vt

### DIFF
--- a/rra-vt/Dockerfile
+++ b/rra-vt/Dockerfile
@@ -1,0 +1,24 @@
+# Start from ubuntu
+FROM node:6
+
+# Update repos and install dependencies
+RUN apt-get update \
+  && apt-get -y upgrade \
+  && apt-get -y install git build-essential libsqlite3-dev zlib1g-dev
+
+# Create a directory and copy in all files
+RUN mkdir -p /tmp/tippecanoe-src
+WORKDIR /tmp/tippecanoe-src
+RUN git clone --branch 1.24.1 https://github.com/mapbox/tippecanoe.git /tmp/tippecanoe-src
+
+# Build tippecanoe
+RUN make \
+  && make install
+
+# Remove the temp directory and unneeded packages
+WORKDIR /
+RUN rm -rf /tmp/tippecanoe-src \
+  && apt-get -y remove --purge build-essential && apt-get -y autoremove
+
+# Install osmtogeojson
+RUN npm install -g osmtogeojson

--- a/rra-vt/README.md
+++ b/rra-vt/README.md
@@ -1,0 +1,19 @@
+# RRA-VT
+
+Dockerfile for the rra-vt
+
+Contains:
+- `osmtogeojson` to convert `.xml` to `.geojson`
+- `tippecanoe` to create the vector tiles
+
+### Commands
+
+osmtogeojson
+```
+docker run -it --rm -v $(pwd):/data wbtransport/rra-vt node --max_old_space_size=8192 /usr/local/bin/osmtogeojson /data/[input.xml] > [output.geojson]
+```
+
+tippecanoe
+```
+docker run -it --rm -v $(pwd):/data wbtransport/rra-vt tippecanoe -l road-network -e /data/[output.mbtiles] [input.geojson]
+```


### PR DESCRIPTION
Adds a new container Dockerfile for rra-vt.
Contains programs to handle vector tile generation

- [ ] Make travis build and publish rra-vt