### PR TITLE
Lock osrm version. Fix #27

### DIFF
--- a/rra-analysis/package.json
+++ b/rra-analysis/package.json
@@ -24,7 +24,7 @@
     "knex": "^0.12.7",
     "lodash.kebabcase": "^4.1.1",
     "minio": "^3.1.3",
-    "osrm": "^5.6.4",
+    "osrm": "5.6.4",
     "pg": "^6.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The fail was related to the needed node version for osrm. https://github.com/Project-OSRM/osrm-backend/issues/4976

I locked the osrm version to the one used when we built this.