### PR TITLE
Fix docker cmd command

### DIFF
--- a/ram-analysis/Dockerfile
+++ b/ram-analysis/Dockerfile
@@ -8,4 +8,6 @@ RUN yarn
 
 RUN mkdir /conversion && cd /conversion && echo "disk=/var/tmp/stxxl,2500,memory" > .stxxl && ln -s /code/node_modules/osrm/profiles/lib/ .
 
-CMD ["node", "--max_old_space_size=8192 index.js"]
+RUN echo 'node --max_old_space_size=8192 index.js' > run.sh
+
+CMD ["bash", "run.sh"]

--- a/ram-analysis/package.json
+++ b/ram-analysis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ram-analysis",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
For some reason docker cmd was not playing along well with --max_old_space_size=8192 throwing this error:

```
Error: illegal value for flag --max_old_space_size=8192 index.js of type int
Try --help for options
node: bad option: --max_old_space_size=8192 index.js
```

This should fix the problem